### PR TITLE
aaa

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-tailwindcss": "^3.15.1",
     "gh-pages": "^6.1.1",
     "postcss": "^8.4.33",
-    "tailwindcss": "^4.1.4",
+    "tailwindcss": "^3.0.0",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"
   }

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -9,7 +9,7 @@ interface ErrorResponse {
   status: number
 }
 
-const serverURL = 'http://localhost:3000/api'
+const serverURL = 'http://94.72.118.5:3000/api'
 
 const http: AxiosInstance = axios.create({
   baseURL: serverURL,


### PR DESCRIPTION
Update the API base URL and downgrade TailwindCSS version.

* Update the `baseURL` in the Axios instance configuration in `frontend/src/lib/http.ts` to `http://94.72.118.5:3000/api`.
* Downgrade the `tailwindcss` version in `frontend/package.json` to `^3.0.0` to resolve the dependency conflict with `@headlessui/tailwindcss`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AleksVale/membrosTotal?shareId=XXXX-XXXX-XXXX-XXXX).